### PR TITLE
Fix: Apply CSS Gradient

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${roboto.className} bg-black text-gray-100 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-gray-900 to-black`}>
+      <body className={`${roboto.className} text-gray-100 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-gray-900 to-black`}>
         <ThemeProvider>
             {children}
             <SpeedInsights />


### PR DESCRIPTION
Correctly applies the CSS gradient background by removing the conflicting class.